### PR TITLE
fix(tests): Fix linter errors in test files

### DIFF
--- a/cmd/alerts-service/handler_test.go
+++ b/cmd/alerts-service/handler_test.go
@@ -137,7 +137,7 @@ func TestCorsMiddleware(t *testing.T) {
 func TestCorsMiddlewarePreflightRequest(t *testing.T) {
 	innerHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)
-		w.Write([]byte("should not reach here for OPTIONS"))
+		_, _ = w.Write([]byte("should not reach here for OPTIONS"))
 	})
 
 	handler := corsMiddleware(innerHandler)
@@ -195,7 +195,7 @@ func TestGzipMiddleware(t *testing.T) {
 			testBody := "This is a test response that should be compressed if gzip is accepted"
 
 			innerHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-				w.Write([]byte(testBody))
+				_, _ = w.Write([]byte(testBody))
 			})
 
 			handler := gzipMiddleware(innerHandler)

--- a/cmd/scraper-service/handler_test.go
+++ b/cmd/scraper-service/handler_test.go
@@ -159,7 +159,7 @@ func TestScraperHandlerWithMockedDependencies(t *testing.T) {
 
 		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			w.Header().Set("Content-Type", "application/json")
-			json.NewEncoder(w).Encode(mockResponse)
+			_ = json.NewEncoder(w).Encode(mockResponse)
 		}))
 		defer server.Close()
 

--- a/internal/waze/client_test.go
+++ b/internal/waze/client_test.go
@@ -6,7 +6,6 @@ import (
 	"net/http/httptest"
 	"strings"
 	"testing"
-	"time"
 
 	"github.com/Lllllllleong/wazePoliceScraperGCP/internal/models"
 )
@@ -172,18 +171,8 @@ func createMockWazeServer(response models.WazeGeoRSSResponse, statusCode int) *h
 	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(statusCode)
-		json.NewEncoder(w).Encode(response)
+		_ = json.NewEncoder(w).Encode(response)
 	}))
-}
-
-// createClientWithMockServer creates a Client that uses the given test server
-func createClientWithMockServer(serverURL string) *Client {
-	return &Client{
-		httpClient: &http.Client{
-			Timeout: 30 * time.Second,
-		},
-		stats: &models.ScrapingStats{},
-	}
 }
 
 // TestGetAlertsWithMockServer tests GetAlerts with a mock HTTP server
@@ -473,7 +462,7 @@ func TestInvalidJSONResponse(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
-		w.Write([]byte("this is not valid json"))
+		_, _ = w.Write([]byte("this is not valid json"))
 	}))
 	defer server.Close()
 


### PR DESCRIPTION
## Summary
Fixes golangci-lint errors that were causing CI/CD failures after PR #1 was merged.

## Changes
- Added error checking for `w.Write()` calls in HTTP test handlers
- Added error checking for `json.Encoder.Encode()` calls in mock servers
- Removed unused `createClientWithMockServer` function
- Removed unused `time` import from client_test.go

## Linter Violations Fixed
1. **errcheck**: Unchecked error returns in:
   - `internal/waze/client_test.go:175` - json.Encoder.Encode()
   - `internal/waze/client_test.go:476` - w.Write()
   - `cmd/alerts-service/handler_test.go:140` - w.Write()
   - `cmd/alerts-service/handler_test.go:198` - w.Write()
   - `cmd/scraper-service/handler_test.go:162` - json.Encoder.Encode()

2. **unused**: Unused function in:
   - `internal/waze/client_test.go:180` - createClientWithMockServer

## Testing
- All unit tests pass locally
- `go test ./...` passes
- No compilation errors

