### PR TITLE
fix: resolve Go linter errors in test files

### DIFF
--- a/cmd/alerts-service/handler_test.go
+++ b/cmd/alerts-service/handler_test.go
@@ -281,7 +281,7 @@ func TestRateLimitMiddleware(t *testing.T) {
 
 	innerHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)
-		w.Write([]byte("success"))
+		_, _ = w.Write([]byte("success"))
 	})
 
 	handler := s.rateLimitMiddleware(innerHandler)

--- a/cmd/scraper-service/handler_test.go
+++ b/cmd/scraper-service/handler_test.go
@@ -159,7 +159,7 @@ func TestScraperHandlerWithMockedDependencies(t *testing.T) {
 
 		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			w.Header().Set("Content-Type", "application/json")
-			json.NewEncoder(w).Encode(mockResponse)
+			_ = json.NewEncoder(w).Encode(mockResponse)
 		}))
 		defer server.Close()
 

--- a/internal/waze/client_test.go
+++ b/internal/waze/client_test.go
@@ -6,7 +6,6 @@ import (
 	"net/http/httptest"
 	"strings"
 	"testing"
-	"time"
 
 	"github.com/Lllllllleong/wazePoliceScraperGCP/internal/models"
 )
@@ -172,18 +171,8 @@ func createMockWazeServer(response models.WazeGeoRSSResponse, statusCode int) *h
 	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(statusCode)
-		json.NewEncoder(w).Encode(response)
+		_ = json.NewEncoder(w).Encode(response)
 	}))
-}
-
-// createClientWithMockServer creates a Client that uses the given test server
-func createClientWithMockServer(serverURL string) *Client {
-	return &Client{
-		httpClient: &http.Client{
-			Timeout: 30 * time.Second,
-		},
-		stats: &models.ScrapingStats{},
-	}
 }
 
 // TestGetAlertsWithMockServer tests GetAlerts with a mock HTTP server
@@ -473,7 +462,7 @@ func TestInvalidJSONResponse(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
-		w.Write([]byte("this is not valid json"))
+		_, _ = w.Write([]byte("this is not valid json"))
 	}))
 	defer server.Close()
 


### PR DESCRIPTION
## Summary
This PR fixes all Go linter errors that were causing CI/CD pipeline failures.

## Fixes
- Fix errcheck: add error handling for `w.Write` in alerts-service handler_test.go
- Fix errcheck: add error handling for `json.NewEncoder().Encode` in waze/client_test.go
- Fix errcheck: add error handling for `w.Write` in waze/client_test.go
- Fix errcheck: add error handling for `json.NewEncoder().Encode` in scraper-service handler_test.go
- Fix unused: remove unused `createClientWithMockServer` function
- Fix unused import: remove unused `time` import

## Files Modified
- cmd/alerts-service/handler_test.go
- cmd/scraper-service/handler_test.go
- internal/waze/client_test.go