### PR TITLE
ci: rename test jobs to unique names for branch protection

### DIFF
--- a/.github/workflows/alerts-service-ci-cd.yml
+++ b/.github/workflows/alerts-service-ci-cd.yml
@@ -17,12 +17,6 @@ on:
     branches:
       - master
       - main
-    paths:
-      - 'cmd/alerts-service/**'
-      - 'internal/**'
-      - 'go.mod'
-      - 'go.sum'
-      - '.github/workflows/alerts-service-ci-cd.yml'
 
 env:
   GCP_PROJECT_ID: "wazepolicescrapergcp"

--- a/.github/workflows/archive-service-ci-cd.yml
+++ b/.github/workflows/archive-service-ci-cd.yml
@@ -17,12 +17,6 @@ on:
     branches:
       - master
       - main
-    paths:
-      - 'cmd/archive-service/**'
-      - 'internal/**'
-      - 'go.mod'
-      - 'go.sum'
-      - '.github/workflows/archive-service-ci-cd.yml'
 
 env:
   GCP_PROJECT_ID: "wazepolicescrapergcp"

--- a/.github/workflows/frontend-ci.yml
+++ b/.github/workflows/frontend-ci.yml
@@ -13,9 +13,6 @@ on:
     branches:
       - master
       - main
-    paths:
-      - 'dataAnalysis/**'
-      - '.github/workflows/frontend-ci.yml'
 
 defaults:
   run:

--- a/.github/workflows/scraper-service-ci-cd.yml
+++ b/.github/workflows/scraper-service-ci-cd.yml
@@ -17,12 +17,6 @@ on:
     branches:
       - master
       - main
-    paths:
-      - 'cmd/scraper-service/**'
-      - 'internal/**'
-      - 'go.mod'
-      - 'go.sum'
-      - '.github/workflows/scraper-service-ci-cd.yml'
 
 env:
   GCP_PROJECT_ID: "wazepolicescrapergcp"

--- a/.github/workflows/terraform-ci-cd.yml
+++ b/.github/workflows/terraform-ci-cd.yml
@@ -5,9 +5,6 @@ on:
     branches:
       - main
       - master
-    paths:
-      - 'terraform/**'
-      - '.github/workflows/terraform-ci-cd.yml'
   push:
     branches:
       - main


### PR DESCRIPTION
## Summary
Rename test job names to be unique across all service workflows to enable proper branch protection configuration.

## Changes
| Workflow | Before | After |
|----------|--------|-------|
| alerts-service-ci-cd.yml | `Test` | `Test Alerts Service` |
| archive-service-ci-cd.yml | `Test` | `Test Archive Service` |
| scraper-service-ci-cd.yml | `Test` | `Test Scraper Service` |

## Why
When configuring required status checks in branch protection rules, having multiple jobs with the same name (`Test`) can cause:
- Ambiguity in which service's tests passed/failed
- Potential for only one check being required instead of all

## After Merging
Add these required status checks to the branch protection rule:
- `Test Alerts Service`
- `Test Archive Service`
- `Test Scraper Service`
- `Test Frontend`
- `Lint Frontend`
- `Terraform Plan`