### PR TITLE
fix: use errors.Is in IsObjectNotExist to handle wrapped GCS errors

### DIFF
--- a/internal/storage/gcs_adapter.go
+++ b/internal/storage/gcs_adapter.go
@@ -3,6 +3,7 @@ package storage
 
 import (
 	"context"
+	"errors"
 	"io"
 
 	gcs "cloud.google.com/go/storage"
@@ -67,14 +68,10 @@ var _ GCSObjectHandle = (*GCSObjectHandleAdapter)(nil)
 // IsObjectNotExist checks if an error indicates that a GCS object does not exist.
 // This works for both the real GCS error and our mock error.
 func IsObjectNotExist(err error) bool {
-	if err == gcs.ErrObjectNotExist {
+	if errors.Is(err, gcs.ErrObjectNotExist) {
 		return true
 	}
-	if err == ErrObjectNotExist {
-		return true
-	}
-	// Check error message as fallback
-	if err != nil && err.Error() == "storage: object doesn't exist" {
+	if errors.Is(err, ErrObjectNotExist) {
 		return true
 	}
 	return false

--- a/internal/storage/gcs_adapter_test.go
+++ b/internal/storage/gcs_adapter_test.go
@@ -1,0 +1,67 @@
+package storage
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+
+	gcs "cloud.google.com/go/storage"
+)
+
+func TestIsObjectNotExist(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{
+			name: "nil error",
+			err:  nil,
+			want: false,
+		},
+		{
+			name: "direct SDK sentinel",
+			err:  gcs.ErrObjectNotExist,
+			want: true,
+		},
+		{
+			name: "wrapped SDK sentinel (GCS SDK v1.57+ regression case)",
+			err:  fmt.Errorf("rpc: %w", gcs.ErrObjectNotExist),
+			want: true,
+		},
+		{
+			name: "double-wrapped SDK sentinel",
+			err:  fmt.Errorf("outer: %w", fmt.Errorf("inner: %w", gcs.ErrObjectNotExist)),
+			want: true,
+		},
+		{
+			name: "direct mock sentinel",
+			err:  ErrObjectNotExist,
+			want: true,
+		},
+		{
+			name: "wrapped mock sentinel",
+			err:  fmt.Errorf("wrapped: %w", ErrObjectNotExist),
+			want: true,
+		},
+		{
+			name: "unrelated error",
+			err:  errors.New("some other error"),
+			want: false,
+		},
+		{
+			name: "bare string matching old message — no longer matches (string fallback removed)",
+			err:  errors.New("storage: object doesn't exist"),
+			want: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := IsObjectNotExist(tt.err)
+			if got != tt.want {
+				t.Errorf("IsObjectNotExist(%v) = %v, want %v", tt.err, got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

- Replaces `==` pointer equality with `errors.Is` in `IsObjectNotExist` (`internal/storage/gcs_adapter.go`)
- Removes the now-incorrect string fallback (`err.Error() == "storage: object doesn't exist"`)
- Adds `internal/storage/gcs_adapter_test.go` with 8 table-driven cases, including the v1.57+ wrapped-error regression case

## Root Cause

GCS SDK v1.57.0 wraps `ErrObjectNotExist` using `fmt.Errorf("%w: %w", ErrObjectNotExist, underlying)`. Pointer equality silently breaks on wrapped errors; `errors.Is` walks the chain correctly.

## Test Plan

- [x] `TestIsObjectNotExist/nil_error`
- [x] `TestIsObjectNotExist/direct_SDK_sentinel`
- [x] `TestIsObjectNotExist/wrapped_SDK_sentinel_(GCS_SDK_v1.57+_regression_case)`
- [x] `TestIsObjectNotExist/double-wrapped_SDK_sentinel`
- [x] `TestIsObjectNotExist/direct_mock_sentinel`
- [x] `TestIsObjectNotExist/wrapped_mock_sentinel`
- [x] `TestIsObjectNotExist/unrelated_error`
- [x] `TestIsObjectNotExist/bare_string_matching_old_message_—_no_longer_matches_(string_fallback_removed)`
- [x] All existing `internal/storage` and service tests pass unchanged

Closes #18