### PR TITLE
ux: cap date picker at Mar 16 2026 and add historical data notice

### DIFF
--- a/dataAnalysis/public/app.js
+++ b/dataAnalysis/public/app.js
@@ -32,6 +32,7 @@ let tokenRefreshInterval = null;
 
 // Constants for date range
 const MIN_DATE = '2025-09-26';
+const MAX_DATE = '2026-03-16'; // Last date with data — collection stopped after this date
 const MAX_SELECTABLE_DATES = 7; // Maximum number of dates that can be selected (reduced due to large data size)
 
 // Helper function to format dates as dd-mm-yyyy HH:MM:SS
@@ -213,14 +214,11 @@ function initMap() {
 
 // Initialize Flatpickr date picker
 function initDatePicker() {
-    // Determine the max selectable date (current day)
-    const today = new Date();
-
     flatpickrInstance = flatpickr('#date-picker', {
         mode: 'multiple',
         dateFormat: 'Y-m-d',
         minDate: MIN_DATE,
-        maxDate: today, 
+        maxDate: MAX_DATE,
         inline: true,
         disable: [
             '2025-10-03', // Hardcoded unavailable date
@@ -295,7 +293,7 @@ async function loadAlertsForSelectedDates() {
         await loadAlertsFromAPI();
 
         if (allAlerts.length === 0) {
-            alertList.innerHTML = '<p class="loading-message" style="color: var(--warning-color);">⚠️ No alerts found for selected dates.</p>';
+            alertList.innerHTML = '<p class="loading-message" style="color: var(--warning-color);">⚠️ No data available for the selected dates. Data is available from Sep 26, 2025 to Mar 16, 2026.</p>';
             loadingStatus.style.display = 'none';
             // Keep button disabled even on empty results - user must reset to try different dates
             loadBtn.disabled = true;

--- a/dataAnalysis/public/index.html
+++ b/dataAnalysis/public/index.html
@@ -115,9 +115,12 @@
     <div class="container">
         <!-- Header -->
         <header>
+            <div class="historical-notice">
+                📦 This dashboard serves <strong>historical data only</strong>. Data was collected from Sep 26, 2025 to Mar 16, 2026.
+            </div>
             <h1>Police Alert Analysis</h1>
             <p class="header-subtitle">
-                Near real-time analysis of police alerts in the Sydney-Canberra region.<br>
+                Historical analysis of police alerts in the Sydney-Canberra region.<br>
                 <br>
                 - Dates available in the calendar represent a full day of continuously sampled data. <br>
                 - Days that are unavailable for selection indicate that the data does not completely represent a whole day of activity.

--- a/dataAnalysis/public/styles.css
+++ b/dataAnalysis/public/styles.css
@@ -55,6 +55,15 @@ header p {
     opacity: 0.9;
 }
 
+.historical-notice {
+    background: rgba(0, 0, 0, 0.25);
+    border: 1px solid rgba(255, 255, 255, 0.3);
+    border-radius: 8px;
+    padding: 10px 16px;
+    margin-bottom: 16px;
+    font-size: 0.95rem;
+}
+
 /* Controls Panel */
 .controls-panel {
     display: grid;


### PR DESCRIPTION
## Summary

- Caps the Flatpickr date picker at `2026-03-16` (last date with data) — users can no longer select dates that will return empty results
- Adds a static banner in the page header: *"This dashboard serves historical data only. Data was collected from Sep 26, 2025 to Mar 16, 2026."*
- Updates the empty results message to include the available date range
- Fixes stale "near real-time analysis" copy in the header subtitle

## Changes

- `app.js` — add `MAX_DATE` constant; use as `maxDate` in Flatpickr; improve empty results message
- `index.html` — add `.historical-notice` banner; update header subtitle
- `styles.css` — add `.historical-notice` styles

Closes #21