### PR TITLE
docs: defluf and audit README, ARCHITECTURE, POST_MORTEM

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ A system for scraping, storing, and analyzing police alert data from Waze's live
 
 ## Project Status: Historical
 
-> **Data collection stopped on March 16, 2026.** The Waze API began returning 403 errors on all requests around January 10, 2026, permanently breaking the scraper. All collected data (September 26, 2025 – March 16, 2026) has been archived to GCS.
+> **Data collection stopped on March 16, 2026.** The Waze API began returning 403 errors on all requests around March 16, 2026, permanently breaking the scraper. All collected data (September 26, 2025 – March 16, 2026) has been archived to GCS.
 >
 > The scraper and archive services have been decommissioned. The dashboard and alerts API remain live and serve the historical dataset. See [docs/POST_MORTEM.md](./docs/POST_MORTEM.md) for the full write-up.
 
@@ -32,15 +32,12 @@ A live version of the data analysis dashboard is deployed and accessible here:
 
 ## Core Features
 
-*   **Automated Data Scraping**: Scheduled Go service fetches and stores police alert data.
-*   **Map Visualization**: Frontend dashboard built with vanilla JavaScript and Leaflet.js displays alerts on a map.
-*   **Timeline View**: Visualizes the lifespan of each alert.
-*   **Filtering**: Tag-based UI filters data by subtypes and streets.
-*   **Microservices Architecture**: Separate services for scraping, serving data, and archiving.
-*   **API Security**: Firebase Anonymous Authentication with per-user rate limiting.
-*   **Infrastructure as Code**: Terraform implementation for infrastructure deployment.
-*   **CI/CD**: Automated build, test, and deployment pipelines using GitHub Actions.
-*   **Serverless**: Built on Cloud Run and Firestore.
+*   **Map + Timeline**: Leaflet.js map and alert lifespan timeline view.
+*   **Filtering**: Filter by subtype and street.
+*   **API**: Firebase Anonymous Auth, per-user rate limiting, gzip JSONL responses.
+*   **IaC**: Terraform for all GCP infrastructure.
+*   **CI/CD**: GitHub Actions — lint, test, Docker build, push, deploy.
+*   **Serverless**: Cloud Run + Firestore.
 
 ---
 
@@ -59,21 +56,17 @@ A live version of the data analysis dashboard is deployed and accessible here:
 
 ## Architecture Overview
 
-The system consists of microservices deployed on Google Cloud Run. Resources are consumed only when services are active.
+*   **`scraper-service`**: Cloud Run job triggered by Cloud Scheduler. Fetches data from Waze, deduplicates by UUID, writes to Firestore.
+*   **`alerts-service`**: HTTP API for the frontend. Checks GCS archives first, falls back to Firestore. Streams gzip JSONL.
+*   **`archive-service`**: Daily Cloud Run job. Moves the previous day's Firestore data to GCS as `archives/YYYY-MM-DD.jsonl.gz`.
 
-*   **`scraper-service`**: Cloud Run job triggered by Cloud Scheduler. Fetches data from Waze, filters and deduplicates, then writes/updates alert data to Firestore.
-*   **`alerts-service`**: Cloud Run API serves alert data to the frontend. Includes Firebase Authentication and rate limiting. Fetches from GCS archives or Firestore, streaming GZIP-compressed JSONL.
-*   **`archive-service`**: Cloud Run job triggered daily by Cloud Scheduler. Moves older data from Firestore to Google Cloud Storage.
-
-For a detailed breakdown of the system design, data flow, and technology rationale, please see the **[Architecture Document](./docs/ARCHITECTURE.md)**.
+See **[Architecture Document](./docs/ARCHITECTURE.md)** for details.
 
 ---
 
 ## Why I Built This
 
-This project started from curiosity during drives between Sydney and Canberra.
-
-Technical decisions are documented in the [ADR (Architectural Decision Record)](./docs/ADR.md).
+Curiosity during drives between Sydney and Canberra. Technical decisions are in the [ADR](./docs/ADR.md).
 
 ---
 
@@ -88,6 +81,8 @@ Technical decisions are documented in the [ADR (Architectural Decision Record)](
 ---
 
 ## Getting Started (Local Development)
+
+> **Note**: The scraper and archive services have been decommissioned and are no longer deployed. The steps below are preserved for reference — only the alerts service and frontend are actively running.
 
 ### Prerequisites
 *   Go (1.24+)
@@ -129,15 +124,22 @@ gcloud auth application-default login
 gcloud config set project YOUR_GCP_PROJECT_ID
 ```
 
-### 4. Run a Backend Service (e.g., Scraper)
+### 4. Run a Backend Service
+
+**Alerts service** (still active):
 ```bash
 # Load environment variables (on Linux/macOS)
 export $(cat .env | xargs)
 
-# Run the scraper service
-go run ./cmd/scraper-service/main.go
+go run ./cmd/alerts-service/main.go
 ```
 The service will start on `http://localhost:8080`.
+
+**Scraper / archive services** (decommissioned — for reference only):
+```bash
+go run ./cmd/scraper-service/main.go
+go run ./cmd/archive-service/main.go
+```
 
 ### 5. Run the Frontend Dashboard
 ```bash
@@ -177,7 +179,7 @@ npm run test:coverage   # With coverage report
 
 | Component | Coverage |
 |-----------|----------|
-| Backend (Go) | ~60% |
+| Backend (Go) | ~15% (target: 60%+) |
 | Frontend (JS) | 100% |
 | Integration Tests | Firestore emulator |
 
@@ -297,6 +299,22 @@ Access via [GCP Monitoring Console](https://console.cloud.google.com/monitoring)
 
 Based on typical usage patterns for this system:
 
+**Post-decommission** (current state — alerts service + frontend only):
+
+| Service                | Usage                          | Estimated Monthly Cost |
+|------------------------|--------------------------------|------------------------|
+| **Cloud Run**          | 1 service (alerts), low traffic | $0 - $1               |
+| **Firestore**          | Read-only, low traffic         | ~$0                    |
+| **Cloud Storage**      | ~10GB static archives          | ~$0.20                 |
+| **Artifact Registry**  | Container image storage        | $0.10 - $0.50          |
+| **Firebase Hosting**   | Static site, minimal bandwidth | Free tier              |
+| **Networking**         | Egress traffic                 | $0 - $1                |
+
+**Total (current)**: ~**$0.30 - $2/month**
+
+<details>
+<summary>Original (when fully operational)</summary>
+
 | Service                | Usage                          | Estimated Monthly Cost |
 |------------------------|--------------------------------|------------------------|
 | **Cloud Run**          | 3 services, minimal traffic    | $0 - $5                |
@@ -308,19 +326,15 @@ Based on typical usage patterns for this system:
 | **BigQuery**           | (Optional) Minimal usage       | $0 - $1                |
 | **Networking**         | Egress traffic                 | $1 - $5                |
 
-**Total Estimated Cost**: **$2 - $25/month**
+**Total**: $2 - $25/month. Assumes scraper every 5-10 minutes, 30-day Firestore retention, low dashboard traffic.
 
-### Cost Optimization Tips
-*   Use Cloud Run's **minimum instances = 0** for auto-scaling to zero
-*   Set up **budget alerts** in GCP Console
-*   Archive old data to **Coldline Storage** ($0.004/GB/month)
-*   Enable **Firestore deletion protection** but regularly clean up old documents
-*   Monitor costs via [GCP Billing Dashboard](https://console.cloud.google.com/billing)
+</details>
 
-**Note**: Costs depend heavily on scraping frequency, data retention, and API traffic. The above estimates assume:
-- Scraper running every 5-10 minutes
-- 30-day data retention in Firestore
-- Low to moderate dashboard usage
+### Cost Tips
+*   Cloud Run minimum instances = 0 (scale to zero)
+*   Set budget alerts in GCP Console
+*   Coldline Storage for archives ($0.004/GB/month)
+*   Monitor via [GCP Billing Dashboard](https://console.cloud.google.com/billing)
 
 ---
 
@@ -346,6 +360,8 @@ Authorization: Bearer <FIREBASE_ID_TOKEN>
 dates=2026-01-08,2026-01-09
 ```
 
+Maximum 7 dates per request.
+
 **Example Request**:
 ```
 GET /police_alerts?dates=2026-01-08,2026-01-09
@@ -357,7 +373,7 @@ GET /police_alerts?dates=2026-01-08,2026-01-09
 {"UUID":"...","Type":"POLICE","Subtype":"POLICE_HIDING","PublishTime":"2026-01-08T11:45:00Z","ExpireTime":"2026-01-08T12:15:00Z",...}
 ```
 
-**Note**: Field names use Go struct field names (e.g., `UUID`, `PublishTime`, `ExpireTime`) as the struct doesn't define JSON tags. See [Data Schema](#data-schema) section below for complete field list.
+**Note**: No JSON tags — field names in responses match Go struct names. See [Data Schema](#data-schema) for the full list.
 
 **Rate Limiting**: 30 requests per minute per authenticated user
 
@@ -401,7 +417,7 @@ type PoliceAlert struct {
 }
 ```
 
-**Note on JSON Serialization**: The `PoliceAlert` struct does not define JSON tags, so when marshaled to JSON (e.g., in API responses), it uses the default Go struct field names (e.g., `UUID`, `PublishTime`, `ExpireTime`) rather than custom JSON names.
+**Note**: No JSON tags on `PoliceAlert`, so field names in API responses match Go struct names (`UUID`, `PublishTime`, `ExpireTime`, etc.).
 
 ### Alert Subtypes
 
@@ -417,7 +433,7 @@ Archived alerts are stored as **JSONL** (JSON Lines) files in Cloud Storage:
 
 **File Path**: `gs://BUCKET_NAME/archives/YYYY-MM-DD.jsonl.gz`
 
-**Format**: One JSON object per line, GZIP compressed
+**Format**: One JSON object per line, stored uncompressed. The `.gz` extension is a misnomer — gzip compression only applies to the HTTP response from the alerts service, not the stored file.
 
 ---
 
@@ -470,13 +486,12 @@ This project is licensed under the MIT License - see the [LICENSE](LICENSE) file
 
 ## Deployment
 
-### Automated Deployment (Recommended)
+### Automated Deployment
 
-GitHub Actions workflows in `.github/workflows/` automatically:
-1.  Lint and test Go code
-2.  Build Docker container
-3.  Push to Google Artifact Registry
-4.  Deploy to Google Cloud Run
+GitHub Actions workflows in `.github/workflows/` handle:
+1.  Lint and test
+2.  Docker build and push to Artifact Registry
+3.  Deploy to Cloud Run
 
 ### Manual Deployment with Terraform
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,7 +1,5 @@
 # System Architecture
 
-This document provides an overview of the Waze Police Scraper project's architecture, detailing its components, data flow, and technology stack.
-
 ---
 
 ## Current State (Post-Decommission, April 2026)
@@ -31,22 +29,13 @@ The original full architecture (scraper pipeline, archive pipeline) is documente
 
 ## 1. High-Level Overview
 
-This project is a cloud-native, event-driven system designed to scrape, store, and visualize police alert data from Waze. It follows a microservices architecture, with distinct services for data collection, data serving, and data archiving. The entire system is deployed on Google Cloud Platform and leverages serverless technologies for scalability and cost-efficiency.
-
-The primary components are:
-*   A **Scraper Service** that periodically fetches data from Waze.
-*   A **Firestore Database** that serves as the central data store for fresh alerts.
-*   An **Alerts Service** (API) that provides data to the frontend dashboard with Firebase Authentication and rate limiting.
-*   An **Archive Service** that moves older data to long-term storage.
-*   A **Data Analysis Dashboard**, which is a vanilla JavaScript single-page application for visualization.
+Three microservices on Cloud Run: a scraper that collects from Waze every minute, an archive service that moves daily Firestore data to GCS, and an alerts API that serves the frontend. Infrastructure is on GCP (Cloud Run, Firestore, GCS, Cloud Scheduler), defined in Terraform.
 
 ---
 
 ## 2. Architecture Diagram
 
-The following diagram illustrates the flow of data and the interaction between the system's components.
-
-> **Note**: This Mermaid diagram requires the "Markdown Preview Mermaid Support" VS Code extension to render in preview. Alternatively, view on GitHub where Mermaid is natively supported.
+> **Note**: Mermaid diagrams render on GitHub natively. In VS Code, install "Markdown Preview Mermaid Support".
 
 ```mermaid
 flowchart TB
@@ -97,80 +86,70 @@ flowchart TB
 ## 3. Component Breakdown
 
 ### 3.1. Scraper Service (`scraper-service`)
-*   **Technology**: Go, deployed on Cloud Run.
-*   **Trigger**: Invoked by Google Cloud Scheduler every minute (`* * * * *`).
-*   **Configuration**: Geographic bounding boxes defined in `configs/bboxes.yaml` (can be overridden via `WAZE_BBOXES` environment variable).
+*   **Technology**: Go on Cloud Run.
+*   **Trigger**: Cloud Scheduler every minute (`* * * * *`).
+*   **Config**: Bounding boxes from `configs/bboxes.yaml` (override via `WAZE_BBOXES` env var).
 *   **Responsibilities**:
-    1.  Receives a trigger to begin a scrape cycle.
-    2.  Makes HTTP requests to the Waze live data endpoints for predefined geographic bounding boxes.
-    3.  Parses the JSON response to extract police-related alerts.
-    4.  Performs data cleaning and transformation into a standardized `PoliceAlert` model.
-    5.  Writes the processed alerts to the `police_alerts` collection in Firestore.
+    1.  Fetches from the Waze live data API for each bounding box.
+    2.  Parses and filters for police-type alerts, deduplicates by UUID across boxes.
+    3.  Transforms into `PoliceAlert` and writes to Firestore, tracking alert lifecycle (initial scrape vs. updates).
 
 ### 3.2. Alerts Service (`alerts-service`)
-*   **Technology**: Go, deployed on Cloud Run.
-*   **Trigger**: HTTPS endpoint protected by Firebase Anonymous Authentication.
+*   **Technology**: Go on Cloud Run.
+*   **Trigger**: HTTPS endpoint, Firebase Anonymous Auth required.
 *   **Responsibilities**:
-    1.  Authenticates incoming requests using Firebase ID tokens.
-    2.  Enforces per-user rate limiting (configurable, default 30 requests/minute).
-    3.  Receives a request from the frontend containing a list of dates.
-    4.  For each date, it first checks if a pre-computed archive exists in Google Cloud Storage (GCS).
-    5.  If an archive exists, it streams the data directly from the GCS file.
-    6.  If no archive exists, it queries Firestore for alerts within that date's 24-hour UTC window.
-    7.  Streams the results back to the frontend as a single, deduplicated JSONL stream with GZIP compression.
-    8.  Acts as a secure proxy, preventing direct database access from the browser.
+    1.  Verifies Firebase ID token, enforces per-user token-bucket rate limiting (default 30 req/min).
+    2.  Accepts up to 7 dates per request.
+    3.  For each date: checks GCS for a pre-computed archive first, falls back to Firestore.
+    4.  Fetches dates in parallel (7 worker goroutines), streams results as gzip-compressed JSONL, deduplicated by UUID.
 
 ### 3.3. Archive Service (`archive-service`)
-*   **Technology**: Go, deployed on Cloud Run.
-*   **Trigger**: Invoked by Google Cloud Scheduler daily at 00:05 UTC (`5 0 * * *`).
-*   **Timezone**: Uses Australia/Canberra timezone for determining day boundaries.
+*   **Technology**: Go on Cloud Run.
+*   **Trigger**: Cloud Scheduler daily at 00:05 UTC (`5 0 * * *`).
+*   **Timezone**: Australia/Canberra for day boundaries.
 *   **Responsibilities**:
-    1.  Receives a trigger to archive a specific day's data (e.g., yesterday).
-    2.  Queries Firestore for all alerts published within that day's 24-hour UTC window.
-    3.  Serializes the alerts into a JSONL file.
-    4.  Uploads the resulting file to a Google Cloud Storage bucket for long-term, cost-effective storage.
-    5.  (Future enhancement): Deletes the archived alerts from Firestore to reduce its size and cost.
+    1.  Queries Firestore for the previous day's alerts.
+    2.  Serializes to JSONL and uploads to GCS as `archives/YYYY-MM-DD.jsonl`.
+    3.  Idempotent — skips dates already archived.
 
 ### 3.4. Data Analysis Dashboard
 *   **Technology**: Vanilla JavaScript (ES6), HTML5, CSS3, hosted on Firebase Hosting.
 *   **Responsibilities**:
-    1.  Authenticates users via Firebase Anonymous Authentication and manages ID token refresh.
-    2.  Provides a user interface for selecting dates and applying filters.
-    3.  Constructs and sends authenticated API requests to the `alerts-service` with Bearer tokens.
-    4.  Parses the streamed JSONL response and loads the data into memory.
-    5.  Performs client-side filtering, sorting, and statistical calculations.
-    6.  Renders the filtered alerts on an interactive map (Leaflet.js with Timeline plugin for temporal visualization) and in a detailed list.
+    1.  Signs in anonymously via Firebase Auth and manages token refresh.
+    2.  Sends authenticated requests to `alerts-service`, parses the streamed JSONL response.
+    3.  Client-side filtering and sorting by subtype and street.
+    4.  Renders alerts on a Leaflet.js map with a timeline plugin for lifespan visualization.
 
 ### 3.5. Supporting Infrastructure
-*   **Artifact Registry**: Docker container images for all Cloud Run services are stored in Google Artifact Registry, enabling version control and efficient deployment workflows.
-*   **BigQuery Dataset**: Provisioned for potential future analytics and data warehouse capabilities, allowing for advanced querying and business intelligence on historical alert data.
+*   **Artifact Registry**: Docker images for all Cloud Run services.
+*   **BigQuery**: Provisioned for potential future analytics; unused.
 
 ---
 
 ## 4. Core Technologies & Rationale
 
-*   **Go**: Chosen for the backend services due to its high performance, low memory footprint (suitable for serverless environments), strong typing, and support for concurrency.
+*   **Go**: Low memory footprint suits Cloud Run's scale-to-zero model; good concurrency primitives for the parallel worker design in the alerts service.
 
-*   **Google Cloud Run**: Selected as the compute platform for its serverless nature. It offers scale-to-zero capabilities, which is cost-effective for services that are invoked periodically. It provides a managed environment, simplifying deployment and operations.
+*   **Cloud Run**: Scale-to-zero keeps costs near-zero for infrequently triggered services (scraper, archive).
 
-*   **Google Cloud Firestore**: Used as the primary database for its ease of use, scalability, and real-time capabilities. Its document-based model is a good fit for the semi-structured nature of the alert data.
+*   **Firestore**: Document model fits the semi-structured Waze alert data; no schema migrations needed as fields evolved.
 
-*   **Google Cloud Storage (GCS)**: Chosen for long-term archival storage due to its low cost and high durability.
+*   **GCS**: Cheap archival storage. Pre-computing daily JSONL archives offloads repeated Firestore queries to flat file reads.
 
-*   **Vanilla JavaScript**: Selected for the frontend to create a lightweight, fast, and dependency-free application. This approach avoids the need for a complex build pipeline.
+*   **Vanilla JS**: No build pipeline, no framework overhead. Business logic is extracted into modules tested with Vitest.
 
-*   **GitHub Actions**: Used for CI/CD to automate the process of building, testing, and deploying the Go microservices to Cloud Run whenever code is pushed to the `main` branch.
+*   **GitHub Actions**: Reusable workflow template keeps the three service pipelines consistent and DRY.
 
-*   **Terraform**: Adopted for Infrastructure as Code (IaC) to manage all GCP resources declaratively. Enables version control, reproducibility, and automated infrastructure deployments with proper state management.
+*   **Terraform**: All GCP resources declarative; decommissioning services meant deleting modules, not manual console clicks.
 
-*   **Firebase Authentication**: Implemented Anonymous Authentication to protect the API endpoints from abuse while maintaining a frictionless user experience. Combined with per-user rate limiting for cost control and service protection.
+*   **Firebase Anonymous Auth**: No registration friction for the dashboard user, while still giving the API a per-user identity for rate limiting.
 
 ---
 
 ## 5. Data Flow Lifecycle
 
-1.  **Collection**: A Cloud Scheduler job triggers the `scraper-service`. The service fetches raw data from Waze, filters for police alerts, and stores them in Firestore.
-2.  **Archival**: A separate daily Cloud Scheduler job triggers the `archive-service`. It reads the previous day's data from Firestore and writes it as a permanent `.jsonl` file to a GCS bucket.
-3.  **Retrieval**: A user visits the dashboard and selects dates. The dashboard calls the `alerts-service` API.
-4.  **Serving**: The `alerts-service` serves the data, preferring GCS archives when available and falling back to live Firestore queries for the most recent data.
-5.  **Visualization**: The dashboard receives the data stream and renders it for the user to analyze.
+1.  **Collection**: Cloud Scheduler → `scraper-service` → Firestore (every minute).
+2.  **Archival**: Cloud Scheduler → `archive-service` → reads Firestore → writes `YYYY-MM-DD.jsonl` to GCS (daily).
+3.  **Retrieval**: Dashboard selects dates → calls `alerts-service`.
+4.  **Serving**: `alerts-service` checks GCS first, falls back to Firestore, streams gzip JSONL.
+5.  **Rendering**: Dashboard parses stream, renders map + timeline.

--- a/docs/POST_MORTEM.md
+++ b/docs/POST_MORTEM.md
@@ -1,15 +1,18 @@
 # Post-Mortem: Waze Police Scraper GCP
 
-**Project lifespan:** September 26, 2025 – March 16, 2026
-**Written:** April 2026
+**Data collection:** September 26, 2025 – March 16, 2026
+
+**Decommissioned:** April 6, 2026
+
+**Written:** April 6, 2026
 
 ---
 
 ## What the Project Was
 
-A cloud-native pipeline that scraped police alert data from the Waze live traffic API across the Sydney–Canberra corridor (Hume Highway), stored it in Firestore, archived it daily to GCS, and served it to a JavaScript dashboard for visualization and analysis. The project started from curiosity during regular drives between Sydney and Canberra.
+A pipeline that scraped police alert data from the Waze live traffic API across the Sydney–Canberra corridor (Hume Highway), stored it in Firestore, archived it daily to GCS, and served it via a JavaScript dashboard. Started from curiosity during regular drives between Sydney and Canberra.
 
-The system ran three microservices on Cloud Run: a scraper (triggered every minute by Cloud Scheduler), an archive service (triggered daily), and an alerts API (public HTTPS endpoint for the frontend). Infrastructure was managed entirely with Terraform, and all services had CI/CD pipelines via GitHub Actions.
+The system ran three microservices on Cloud Run: a scraper (triggered every minute by Cloud Scheduler), an archive service (triggered daily), and an alerts API (public HTTPS endpoint for the frontend). Infrastructure was defined in Terraform; all services had CI/CD pipelines via GitHub Actions.
 
 ---
 
@@ -36,9 +39,9 @@ The system ran three microservices on Cloud Run: a scraper (triggered every minu
 
 **Terraform for infrastructure.** Having all GCP resources defined in Terraform made the decommission clean — removing modules from `main.tf` was sufficient to express the desired end state. Dependency ordering (schedulers before services) was handled automatically.
 
-**CI/CD pipelines.** The GitHub Actions workflows gave high confidence in every deployment. The reusable workflow pattern kept the three service pipelines consistent. Coverage thresholds caught regressions early.
+**CI/CD pipelines.** The reusable workflow pattern kept the three service pipelines consistent. Coverage thresholds caught regressions early.
 
-**Firebase Anonymous Authentication + rate limiting.** The alerts API was never directly abused despite being publicly discoverable. Anon auth with per-user token-bucket rate limiting was a lightweight but effective protection at this scale.
+**Firebase Anonymous Authentication + rate limiting.** The alerts API was never abused despite being publicly discoverable. Anon auth with per-user token-bucket rate limiting held up fine at this scale.
 
 **Serverless economics.** The entire system ran at near-zero cost during active collection (~$5–10/month). After decommission, the remaining infrastructure (alerts API on Cloud Run, Firebase Hosting, Firestore, GCS) costs effectively nothing.
 


### PR DESCRIPTION
## Summary

- Fix factual inaccuracies found during audit:
  - Backend coverage claimed ~60%; actual CI threshold is 15% (60% is a TODO target)
  - Cost table reflected 3 services + 2 scheduler jobs; updated to post-decommission state (1 service, ~$0.30–2/month)
  - Archive files described as GZIP on disk; they're plain JSONL — gzip only applies to the HTTP response
  - API docs missing the 7-date-per-request limit
- POST_MORTEM: split "project lifespan" into data collection end (Mar 16) and decommission (Apr 6)
- ARCHITECTURE: remove stale future-enhancement note; add worker count and dedup detail to alerts service
- Getting Started: add decommission notice rather than deleting the steps

## Test plan
- [ ] Verify Mermaid diagrams, details block, and tables render correctly on GitHub