### PR TITLE
ci: allow workflow_dispatch to deploy and watch reusable workflow

### DIFF
--- a/.github/workflows/alerts-service-ci-cd.yml
+++ b/.github/workflows/alerts-service-ci-cd.yml
@@ -11,6 +11,7 @@ on:
       - 'go.sum'
       - 'Dockerfile.alerts'
       - '.github/workflows/alerts-service-ci-cd.yml'
+      - '.github/workflows/reusable-service-cicd.yml'
   pull_request:
     branches: [master, main]
 

--- a/.github/workflows/reusable-service-cicd.yml
+++ b/.github/workflows/reusable-service-cicd.yml
@@ -73,7 +73,7 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     needs: test
-    if: github.event_name == 'push' && (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/master')
+    if: (github.event_name == 'push' || github.event_name == 'workflow_dispatch') && (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/master')
     permissions:
       contents: read
       id-token: write


### PR DESCRIPTION
## Summary
- Add `workflow_dispatch` to the deploy job condition so manual triggers on main can redeploy without needing a code push
- Add `reusable-service-cicd.yml` to the alerts-service path filter so changes to it trigger a full CI/CD run

## Why
`workflow_dispatch` runs were only running the test job and skipping deploy, making manual redeploys impossible without a code change. Merging this PR will also immediately trigger a deploy of the current `main` code.